### PR TITLE
Switch to pyproj CRS object for all CRS operations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 exclude = .git,__pycache__,build,dist,versioneer.py,geoxarray/_version.py,docs/source/conf.py
+max-line-length = 120

--- a/README.rst
+++ b/README.rst
@@ -8,11 +8,52 @@ GeoXArray
 .. image:: https://img.shields.io/pypi/v/geoxarray.svg
         :target: https://pypi.python.org/pypi/geoxarray
 
-
-Geolocation utilities for xarray objects
-
 * Free software: Apache 2
 * Documentation: (COMING SOON!) https://geoxarray.github.io/geoxarray.
+
+Geolocation utilities for xarray objects. GeoXArray is meant to bring
+together all of the features and conversions needed by various python
+packages working with geolocation xarray objects. This means being
+able to convert between various coordinate system implementations
+(rasterio, cartopy, pyresample, NetCDF CF grid mapping, etc). It also
+means providing basic access to properties of the geolocation information
+like bounding boxes.
+
+Installation
+------------
+
+The ``geoxarray`` library will be available on PyPI and can be installed with
+pip::
+
+    pip install geoxarray
+
+For the most recent development versions of geoxarray, it can be installed
+directly from the root of the source directory::
+
+    pip install -e .
+
+In the future geoxarray will also be available on conda-forge.
+
+Dependencies
+------------
+
+Besides the xarray dependency, the ``geoxarray`` uses CRS objects
+from the `pyproj <https://pyproj4.github.io/pyproj/stable/>`_ library
+Additionally, geoxarray has a lot of optional dependencies when it comes
+to converting to other libraries' CRS or geolocation objects. These
+libraries include, but may not be limited to:
+
+- rasterio
+- cartopy
+- pyresample
+
+Development Status
+------------------
+
+GeoXArray is actively being developed as a side project. Additions and
+modifications are done as developers have time. If you would like to
+contribute, suggest features, or discuss anything else please file a
+bug on github.
 
 Features
 --------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,10 @@
-============
 Installation
 ============
 
 At the command line::
 
     $ pip install geoxarray
+
+Or with conda via conda-forge::
+
+    $ conda install -c conda-forge geoxarray

--- a/geoxarray/__init__.py
+++ b/geoxarray/__init__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .crs import CRS
+from .crs import CRS  # noqa
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/geoxarray/accessor.py
+++ b/geoxarray/accessor.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright geoxarray Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""XArray extensions via accessor objects.
+
+The functionality in this module can be accessed via the `.geo` accessor on
+any xarray DataArray or Dataset object.
+
+Geolocation cases that these accessors are supposed to be able to handle:
+
+1. CF compliant Dataset: A :class:`~xarray.Dataset` object with one or
+   more data variables and one CRS specification variable. By default
+   a 'grid_mapping' attribute is used to specify the name of the variable.
+
+   http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch05s06.html
+
+"""
+
+import xarray as xr
+
+try:
+    from pyresample.geometry import AreaDefinition, SwathDefinition
+    has_pyresample = True
+except ImportError:
+    AreaDefinition = SwathDefinition = None
+    has_pyresample = False
+
+
+try:
+    from rasterio.crs import CRS as RioCRS
+    has_rasterio = True
+except ImportError:
+    RioCRS = None
+    has_rasterio = False
+
+
+class _SharedGeoAccessor(object):
+    """Accessor functionality shared between Dataset and DataArray objects."""
+
+    def __init__(self, xarray_obj):
+        self._obj = xarray_obj
+        # self._center = None
+        self._crs = None
+        self._is_gridded = True
+        self._cf_grid_mapping_parameters = None
+
+    @property
+    def cf_grid_mapping_parameters(self):
+        return self._cf_grid_mapping_parameters
+
+    @cf_grid_mapping_parameters.setter
+    def cf_grid_mapping_parameters(self, value):
+        self._cf_grid_mapping_parameters = value
+        # reset the CRS object so it gets recalculated
+        self._crs = None
+
+    def find_cf_grid_mapping(self):
+        """Search for CF standard grid mapping information."""
+        return self._cf_grid_mapping_parameters
+
+    @property
+    def crs(self):
+        if self._crs is not None:
+            return self._crs
+
+        coords_crs = self._obj.coords.get('crs')
+        attrs_crs = self._obj.attrs.get('crs')
+        area = self._obj.attrs.get('area')
+        cf_mapping_params = self.find_cf_grid_mapping()
+        self._is_gridded = True
+        if cf_mapping_params:
+            # TODO: Convert CF params to CRS object
+            self._cf_grid_mapping_parameters = cf_mapping_params
+        elif coords_crs is not None:
+            crs = coords_crs
+            # TODO: Convert to geoxarray CRS object
+        elif attrs_crs is not None:
+            crs = attrs_crs
+            # TODO: Convert to geoxarray CRS object
+        elif has_pyresample and isinstance(area, AreaDefinition):
+            # TODO: Convert and gather information from definitions
+            pass
+        elif has_pyresample and isinstance(area, SwathDefinition):
+            # TODO: Convert and gather information from definitions
+            self._is_gridded = False
+        self._crs = crs
+        return self._crs
+
+    @crs.setter
+    def crs(self, value):
+        """Force the CRS for this object.
+
+        Set to `None` for the CRS to be recalculated.
+
+        """
+        self._crs = value
+
+    def get_lonlats(self, chunks=None):
+        """Return longitude and latitude arrays.
+
+        Parameters
+        ----------
+        chunks : None or int
+            Specify chunk size for dask arrays.
+
+        Returns
+        -------
+        Longitude and latitude dask arrays. If `chunks` is None then a
+        numpy array is returned.
+
+        """
+        raise NotImplementedError()
+
+    def plot(self):
+        """Plot data on a map."""
+        raise NotImplementedError()
+
+    def freeze(self):
+        """Set a 'crs' coordinate to the current computed CRS.
+
+        This modifies the current metadata and assumes that no new CRS
+        information will be added or modified from now on.
+
+        """
+        # XXX: Is this useful or needed at all?
+        raise NotImplementedError()
+
+
+@xr.register_dataset_accessor('geo')
+class GeoDatasetAccessor(_SharedGeoAccessor):
+    def find_cf_grid_mapping(self):
+        """Search for CF standard grid mapping information."""
+        params = super(GeoDataArrayAccessor, self).find_cf_grid_mapping()
+        if not params and 'grid_mapping' in self._obj.attrs:
+            params = self._obj.variables[self._obj.attrs['grid_mapping']]
+        return params
+
+    def set_cf_grid_mapping_parameters(self, grid_mapping_var_name):
+        """Specify the variable containing the CF-compliant CRS information"""
+        raise NotImplementedError()
+
+    def set_ungridded_coordinates(self, lon_var_name, lat_var_name):
+        """Specify longitude and latitude variables defining geolocation.
+
+        Setting geolocation this way can be useful when using lazy arrays
+        (dask) and computing large lon/lat arrays could be wasteful when
+        stored in `.coords`.
+
+        """
+        raise NotImplementedError()
+
+    def set_xy_variables(self, x_var_name, y_var_name):
+        """Specify the variables defining the X and Y coordinates for the gridded data.
+
+        This method assumes 'grid_mapping' is either already set in `.attrs`
+        or will be set with `set_grid_mapping`.
+
+        """
+        raise NotImplementedError()
+
+
+@xr.register_dataarray_accessor('geo')
+class GeoDataArrayAccessor(_SharedGeoAccessor):
+    pass

--- a/geoxarray/crs/__init__.py
+++ b/geoxarray/crs/__init__.py
@@ -38,5 +38,3 @@ None currently
 import logging
 
 LOG = logging.getLogger(__name__)
-
-import accessor  # noqa

--- a/geoxarray/crs/__init__.py
+++ b/geoxarray/crs/__init__.py
@@ -36,78 +36,7 @@ None currently
 """
 
 import logging
-from ._proj4 import proj4_to_geoxarray, geoxarray_to_proj4, proj4_dict_to_str
-
-try:
-    from rasterio.crs import CRS as RIOCRS
-except ImportError:
-    CRS = None
-
-try:
-    from ._cartopy import from_proj as cartopy_from_proj
-except ImportError:
-    cartopy_from_proj = None
 
 LOG = logging.getLogger(__name__)
 
-# XXX: Best way to include descriptions of parameters
-# parameter -> description (?)
-CRS_PARAMETERS = {
-
-}
-
-
-class CRS(dict):
-    """Basic Coordinate Reference System (CRS) description container.
-
-    Typical usage of this object is as a container and as a converter
-    between the different ways to describe a CRS.
-
-    Examples
-    --------
-
-    TODO
-
-    """
-
-    def __init__(self, *args, **kwargs):
-        """Create a CRS object from CF standard parameters.
-
-        For possible parameters see the :mod:`geoxarray.crs`.
-
-        """
-        self._proj = None
-        self._proj4_str = None
-        self._proj4_dict = None
-        self._cartopy_crs = None
-        self._rasterio_crs = None
-        super(CRS).__init__(*args, **kwargs)
-
-    @property
-    def proj4_dict(self):
-        if self._proj4_dict is None:
-            self._proj4_dict = geoxarray_to_proj4(**self)
-        return self._proj4_dict
-
-    @property
-    def proj4_str(self):
-        if self._proj4_str is None:
-            pd = self.proj4_dict
-            self._proj4_str = proj4_dict_to_str(pd, sort=True)
-        return self._proj4_str
-
-    @property
-    def cartopy_crs(self):
-        if self._cartopy_crs is None:
-            if cartopy_from_proj is None:
-                raise ImportError("'cartopy' must be installed")
-            self._cartopy_crs = cartopy_from_proj(self.proj4_dict)
-        return self._cartopy_crs
-
-    @property
-    def rasterio_crs(self):
-        if self._rasterio_crs is None:
-            if RIOCRS is None:
-                raise ImportError("'rasterio' must be installed")
-            self._rasterio_crs = RIOCRS(**self)
-        return self._rasterio_crs
+import accessor  # noqa

--- a/geoxarray/crs/_proj4.py
+++ b/geoxarray/crs/_proj4.py
@@ -22,7 +22,7 @@ functions.
 
 """
 
-from pyproj import Proj, Geod
+from pyproj import CRS
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -34,39 +34,17 @@ PROJ_TO_GX = {
 }
 
 
-def proj4_to_geoxarray(**kwargs):
-    """Convert a PROJ.4 dict to a dict of geoxarray CRS parameters."""
-    raise NotImplementedError()
-
-
-def geoxarray_to_proj4(**kwargs):
-    """Convert a dict of geoxarray CRS parameters to a PROJ.4 dict."""
-    raise NotImplementedError()
-
-
 def proj4_str_to_dict(proj4_str):
     """Convert PROJ.4 compatible string definition to dict
 
     Note: Key only parameters will be assigned a value of `True`.
     """
-    pairs = (x.split('=', 1) for x in proj4_str.replace('+', '').split(" "))
-    return dict((x[0], (x[1] if len(x) == 2 else True)) for x in pairs)
+    return CRS(proj4_str).to_dict()
 
 
 def proj4_dict_to_str(proj4_dict, sort=False):
     """Convert a dictionary of PROJ.4 parameters to a valid PROJ.4 string"""
-    items = proj4_dict.items()
-    if sort:
-        items = sorted(items)
-    params = []
-    for key, val in items:
-        key = str(key) if key.startswith('+') else '+' + str(key)
-        if key in ['+no_defs', '+no_off', '+no_rot']:
-            param = key
-        else:
-            param = '{}={}'.format(key, val)
-        params.append(param)
-    return ' '.join(params)
+    return CRS(proj4_dict).to_proj4()
 
 
 def proj4_radius_parameters(proj4_dict):
@@ -78,28 +56,5 @@ def proj4_radius_parameters(proj4_dict):
     Returns:
         a (float), b (float): equatorial and polar radius
     """
-    if isinstance(proj4_dict, str):
-        new_info = proj4_str_to_dict(proj4_dict)
-    else:
-        new_info = proj4_dict.copy()
-
-    # load information from PROJ.4 about the ellipsis if possible
-    if 'ellps' in new_info:
-        geod = Geod(**new_info)
-        new_info['a'] = geod.a
-        new_info['b'] = geod.b
-    elif 'a' not in new_info or 'b' not in new_info:
-
-        if 'rf' in new_info and 'f' not in new_info:
-            new_info['f'] = 1. / float(new_info['rf'])
-
-        if 'a' in new_info and 'f' in new_info:
-            new_info['b'] = float(new_info['a']) * (1 - float(new_info['f']))
-        elif 'b' in new_info and 'f' in new_info:
-            new_info['a'] = float(new_info['b']) / (1 - float(new_info['f']))
-        else:
-            geod = Geod(**{'ellps': 'WGS84'})
-            new_info['a'] = geod.a
-            new_info['b'] = geod.b
-
-    return float(new_info['a']), float(new_info['b'])
+    crs = CRS(proj4_dict)
+    return crs.semi_major_metre, crs.semi_minor_metre

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # List required packages in this file, one per line.
 xarray
+pyproj>=2.2


### PR DESCRIPTION
And other cleanup. Pyproj's CRS object is used more widely and allows for easy conversion to/from various CRS-like objects used throughout the scientific python ecosystem. There was even discussion at SciPy 2019 (@dopplershift @snowman2) of a possible future where pyproj CRS objects can be used by Cartopy (either as a base class or a starting point for conversion).

This is really just pushing stuff that was sitting on my local machine for a long time.