### PR TITLE
Add automatic deployment of sphinx to github pages repos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  release:
+    types:
+      - published
+  push:
+  pull_request:
 
 jobs:
   lint:
@@ -54,6 +59,30 @@ jobs:
         run: |
           cd docs; \
           make html SPHINXOPTS="-W"
+
+      - name: deploy website
+        if: github.event_name == 'release'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GEOXARRAY_WEBSITE_TOKEN }}
+          publish_dir: docs/build/html
+          publish_branch: main
+          destination_dir: ${{ github.ref }}
+          allow_empty_commit: true
+          external_repository: geoxarray/geoxarray.github.io
+          full_commit_message: "Deploy geoxarray.github.io website for SHA:$GITHUB_SHA (Tag: $GITHUB_REF)"
+
+      - name: deploy website
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GEOXARRAY_WEBSITE_TOKEN }}
+          publish_dir: docs/build/html
+          publish_branch: main
+          destination_dir: latest
+          allow_empty_commit: true
+          external_repository: geoxarray/geoxarray.github.io
+          full_commit_message: "Deploy geoxarray.github.io website for SHA:$GITHUB_SHA (Tag: $GITHUB_REF)"
 
   test:
     runs-on: ${{ matrix.os }}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,8 @@
 GeoXArray Documentation
 =======================
 
+Documentation coming soon...
+
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
First attempt at getting documentation to be automatically deployed to geoxarray.github.io. I've created a separate repository for it here: https://github.com/geoxarray/geoxarray.github.io since I'm not a huge fan of the gh-pages branch concept. Let's see what happens.

Edit: The plan is to work on the documentation content after this works.