### PR TITLE
Add basic test for pyresample AreaDefinition CRS support

### DIFF
--- a/geoxarray/accessor.py
+++ b/geoxarray/accessor.py
@@ -212,15 +212,10 @@ class _SharedGeoAccessor:
             return None
 
     def _get_crs_from_pyresample(self):
-        if has_pyresample is None:
-            return None
         area = self._obj.attrs.get("area")
         if area is None:
             return None
-        if isinstance(area, AreaDefinition):
-            return area.crs
-        if isinstance(area, SwathDefinition):
-            # TODO: Set whether or not things are gridded?
+        if hasattr(area, "crs"):
             return area.crs
         return None
 

--- a/geoxarray/tests/test_accessor/_data_array_cases.py
+++ b/geoxarray/tests/test_accessor/_data_array_cases.py
@@ -13,11 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test cases for DataArray-specific interfaces."""
+from __future__ import annotations
+
 import xarray as xr
 from dask import array as da
 from pyproj import CRS
 
-from ._shared import ALT_DIM_SIZE, OTHER_DIM_SIZE, TIME_DIM_SIZE, X_DIM_SIZE, Y_DIM_SIZE
+from ._shared import (
+    ALT_DIM_SIZE,
+    OTHER_DIM_SIZE,
+    TIME_DIM_SIZE,
+    X_DIM_SIZE,
+    Y_DIM_SIZE,
+    AreaDefinition,
+)
 
 
 def geotiff_y_x():
@@ -143,3 +152,22 @@ def cf_y_x_with_bad_crs():
 
 def no_crs_no_dims_2d():
     return xr.DataArray(da.empty((Y_DIM_SIZE, X_DIM_SIZE)))
+
+
+def pyr_geos_area_2d() -> xr.DataArray:
+    geos_crs = CRS.from_dict(
+        {
+            "proj": "geos",
+            "sweep": "x",
+            "lon_0": -75,
+            "h": 35786023,
+            "ellps": "GRS80",
+            "no_defs": None,
+        }
+    )
+    area = AreaDefinition(
+        "", "", "", geos_crs, 200, 100, (-5434894.885056, -5434894.885056, 5434894.885056, 5434894.885056)
+    )
+    data_arr = no_crs_no_dims_2d()
+    data_arr.attrs["area"] = area
+    return data_arr

--- a/geoxarray/tests/test_accessor/_shared.py
+++ b/geoxarray/tests/test_accessor/_shared.py
@@ -20,6 +20,12 @@ from pyproj import CRS
 
 from geoxarray.accessor import DEFAULT_GRID_MAPPING_VARIABLE_NAME
 
+try:
+    from pyresample import AreaDefinition
+except ImportError:
+    AreaDefinition = None
+
+
 X_DIM_SIZE = 20
 Y_DIM_SIZE = 10
 ALT_DIM_SIZE = 5

--- a/geoxarray/tests/test_accessor/test_accessor_data_arr.py
+++ b/geoxarray/tests/test_accessor/test_accessor_data_arr.py
@@ -32,9 +32,16 @@ from ._data_array_cases import (
     misc_y_x_z,
     misc_z_y_x,
     no_crs_no_dims_2d,
+    pyr_geos_area_2d,
     raw_coords_lats1d_lons1d,
 )
-from ._shared import ALT_DIM_SIZE, X_DIM_SIZE, Y_DIM_SIZE, check_written_crs
+from ._shared import (
+    ALT_DIM_SIZE,
+    X_DIM_SIZE,
+    Y_DIM_SIZE,
+    AreaDefinition,
+    check_written_crs,
+)
 
 
 @pytest.mark.parametrize(
@@ -102,3 +109,9 @@ def test_no_crs_write_crs(inplace, gmap_var_name):
 
     assert new_data_arr is data_arr if inplace else new_data_arr is not data_arr
     check_written_crs(new_data_arr, new_crs, gmap_var_name)
+
+
+@pytest.mark.skipif(AreaDefinition is None, reason="Missing 'pyresample' dependency")
+def test_pyresample_area_2d_crs():
+    data_arr = pyr_geos_area_2d()
+    assert data_arr.geo.crs == data_arr.attrs["area"].crs

--- a/setup.py
+++ b/setup.py
@@ -40,13 +40,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     python_requires=">=3.9",
-    package_data={
-        "geoxarray": [
-            # When adding files here, remember to update MANIFEST.in as well,
-            # or else they will not be included in the distribution on PyPI!
-            # 'path/to/data_file',
-        ]
-    },
     install_requires=requirements,
     extras_require=extras_require,
     tests_require=["pytest", "dask", "pyresample"],


### PR DESCRIPTION
Support for `.geo.crs` pulling the CRS from `.attrs["area"].crs` already existed, it just wasn't tested.