### PR TITLE
Make 'write_crs' default to builtin CRS information

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd docs; \
+          make doctest; \
           make html SPHINXOPTS="-W"
 
 #      - name: Prepare tag

--- a/.github/workflows/deploy-sdist.yaml
+++ b/.github/workflows/deploy-sdist.yaml
@@ -8,6 +8,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/geoxarray
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout source
@@ -15,11 +20,8 @@ jobs:
 
       - name: Create sdist
         shell: bash -l {0}
-        run: python setup.py sdist
+        run: python -m pip install build; python -m build -s
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@v1.4.1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+        uses: pypa/gh-action-pypi-publish@v1.8.8

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,11 @@ help:
 
 .PHONY: help Makefile
 
+
+clean:
+	rm source/api/*.rst
+	rm -r build/*
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -216,12 +216,13 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    "xarray": ("https://xarray.pydata.org/en/stable", None),
+    "xarray": ("https://docs.xarray.dev/en/stable", None),
     "dask": ("https://dask.pydata.org/en/latest", None),
-    "matplotlib": ("https://matplotlib.org", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
     "pyproj": ("https://pyproj4.github.io/pyproj/stable", None),
+    "proj": ("https://proj.org/en/latest", None),
     "rioxarray": ("https://corteva.github.io/rioxarray/stable", None),
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -225,4 +225,6 @@ intersphinx_mapping = {
     "pyproj": ("https://pyproj4.github.io/pyproj/stable", None),
     "proj": ("https://proj.org/en/latest", None),
     "rioxarray": ("https://corteva.github.io/rioxarray/stable", None),
+    "pyresample": ("https://pyresample.readthedocs.io/en/stable", None),
+    "satpy": ("https://satpy.readthedocs.io/en/stable", None),
 }

--- a/docs/source/howtos/access_crs.rst
+++ b/docs/source/howtos/access_crs.rst
@@ -1,0 +1,137 @@
+Access CRS information
+======================
+
+Geoxarray can understand a couple different standard ways of storing
+Coordinate Reference System (CRS) information in an Xarray object.
+To learn more about what a CRS is see the :doc:`../topics/projections`
+documentation.
+
+Below you'll find examples of the common CRS storage cases that geoxarray
+supports. In all cases, the basic access geoxarray usage is the same. Please
+follow the specific storage format section closest to your use case for
+details on what geoxarray expects. The basic usage, assuming you have an
+xarray DataArray or Dataset object, is to do:
+
+.. code-block::
+
+   import geoxarray
+
+   the_crs = my_data_arr.geo.crs
+
+To access geoxarray's ``.geo`` accessor (the property) we must first import
+geoxarray to register it. Then accessing
+:meth:`.geo.crs <geoxarray.accessor._SharedGeoAccessor.crs>` gives us a pyproj
+:class:`~pyproj.crs.CRS` object or ``None`` if geoxarray is unable to determine
+the CRS.
+
+.. contents:: Supported CRS Formats
+
+CF Grid Mapping
+---------------
+
+If loading a NetCDF file that has a CF-compatible "grid mapping" variable,
+you can load the file in a geoxarray-friendly way by doing:
+
+.. code-block:: python
+
+    import xarray as xr
+    ds = xr.open_dataset("/path/to/file.nc", decode_coords="all")
+
+The ``decode_coords="all"`` is required for the grid mapping coordinates to
+be loaded in a way that geoxarray can understand and access.
+
+Single Grid Mapping
+^^^^^^^^^^^^^^^^^^^
+
+.. testsetup::
+
+   import xarray as xr
+   import numpy as np
+   data_arr = xr.DataArray(np.zeros((20, 10)),
+                           dims=("y", "x"),
+                           coords={
+                               "y": np.arange(20.0),
+                               "x": np.arange(10.0),
+   })
+   gmap_var = xr.DataArray(0.0, attrs={
+     'long_name': 'GOES-R ABI fixed grid projection',
+     'grid_mapping_name': 'geostationary',
+     'perspective_point_height': 35786023.0,
+     'semi_major_axis': 6378137.0,
+     'semi_minor_axis': 6356752.31414,
+     'inverse_flattening': 298.2572221,
+     'latitude_of_projection_origin': 0.0,
+     'longitude_of_projection_origin': -75.0,
+     'sweep_angle_axis': 'x'})
+   data_arr.encoding["grid_mapping"] = "goes_imager_projection"
+   data_arr.coords["goes_imager_projection"] = gmap_var
+   ds = xr.Dataset({"Rad": data_arr})
+
+Let's say the file we loaded above looks something like this:
+
+.. testcode::
+
+   print(ds)
+
+.. testoutput::
+
+   <xarray.Dataset>
+   Dimensions:                 (y: 20, x: 10)
+   Coordinates:
+     * y                       (y) float64 0.0 1.0 2.0 3.0 ... 16.0 17.0 18.0 19.0
+     * x                       (x) float64 0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0
+       goes_imager_projection  float64 0.0
+   Data variables:
+       Rad                     (y, x) float64 0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0
+
+This Dataset has ``x`` and ``y`` dimensions and coordinate variables and a
+single ``Rad`` data variable. There is one grid mapping variable with the
+following metadata:
+
+.. testcode::
+
+   print(ds.coords["goes_imager_projection"].attrs)
+
+.. testoutput::
+
+   {'long_name': 'GOES-R ABI fixed grid projection', 'grid_mapping_name': 'geostationary', 'perspective_point_height': 35786023.0, 'semi_major_axis': 6378137.0, 'semi_minor_axis': 6356752.31414, 'inverse_flattening': 298.2572221, 'latitude_of_projection_origin': 0.0, 'longitude_of_projection_origin': -75.0, 'sweep_angle_axis': 'x'}
+
+To get the CRS information for this ``Rad`` variable we can do:
+
+.. testcode::
+
+   import geoxarray
+
+   print(repr(ds["Rad"].geo.crs))
+
+.. testoutput::
+   :options: +NORMALIZE_WHITESPACE
+
+   <Projected CRS: {"$schema": "https://proj.org/schemas/v0.2/projjso ...>
+   Name: undefined
+   Axis Info [cartesian]:
+   - E[east]: Easting (metre)
+   - N[north]: Northing (metre)
+   Area of Use:
+   - undefined
+   Coordinate Operation:
+   - name: unknown
+   - method: Geostationary Satellite (Sweep X)
+   Datum: undefined
+   - Ellipsoid: undefined
+   - Prime Meridian: Greenwich
+
+Due to some differences between CF's standard grid mapping definitions and the
+amount of details made available via pyproj/PROJ and the amount of missing
+information in this example (but real-world) CRS, many of the fields in this
+CRS are listed as "undefined" or "unknown". This CRS is still perfectly
+valid and usable by geoxarray and pyproj.
+
+**Details**
+
+In the CF NetCDF case, geoxarray looks for a ``grid_mapping`` name in
+``.encoding`` or ``.attrs`` and then looks for that variable in ``.coords``.
+The CRS is then constructed from the metadata in that grid mapping variable's
+``.attrs``. If the grid mapping variable's metadata (``.attrs``) includes a
+Well-Known Text (WKT) version of the CRS (a ``crs_wkt`` or ``spatial_ref``
+attribute) then the CRS will be derived from that.

--- a/docs/source/howtos/access_crs.rst
+++ b/docs/source/howtos/access_crs.rst
@@ -25,6 +25,9 @@ geoxarray to register it. Then accessing
 the CRS.
 
 .. contents:: Supported CRS Formats
+   :depth: 1
+   :backlinks: none
+   :local:
 
 CF Grid Mapping
 ---------------
@@ -135,3 +138,62 @@ The CRS is then constructed from the metadata in that grid mapping variable's
 ``.attrs``. If the grid mapping variable's metadata (``.attrs``) includes a
 Well-Known Text (WKT) version of the CRS (a ``crs_wkt`` or ``spatial_ref``
 attribute) then the CRS will be derived from that.
+
+Satpy and Pyresample
+--------------------
+
+The :doc:`Satpy <satpy:index>` library uses
+:doc:`Pyresample <pyresample:index>` geometry objects to define the geographic
+region of a dataset. The most common objects are
+:class:`pyresample.geometry.AreaDefinition` and
+:class:`pyresample.geometry.SwathDefinition` objects and are typically found in
+a DataArray in ``.attrs["area"]``.
+
+.. testsetup::
+
+   import xarray as xr
+   import dask.array as da
+   from pyresample import AreaDefinition
+   area = AreaDefinition("", "", "", "EPSG:3070", 10, 20,
+                         (282455.22, 223080.17, 828240.35, 766436.45))
+   satpy_data_arr = xr.DataArray(da.zeros((20, 10)),
+                           dims=("y", "x"), attrs={"area": area})
+
+.. testcode::
+
+   print(satpy_data_arr)
+
+.. testoutput::
+   :options: +SKIP
+
+   <xarray.DataArray 'zeros_like-3a0478cfb7d335c932035a68e3cac66f' (y: 20, x: 10)>
+   dask.array<zeros_like, shape=(20, 10), dtype=float64, chunksize=(20, 10), chunktype=numpy.ndarray>
+   Dimensions without coordinates: y, x
+   Attributes:
+       area:     Area ID: \nDescription: \nProjection: {'datum': 'NAD83', 'k': '...
+
+These objects have a ``.crs`` property and
+is directly returned by geoxarray if the other formats of CRS information
+(see above) are not found.
+
+.. testcode::
+
+   print(repr(satpy_data_arr.geo.crs))
+
+.. testoutput::
+   :options: +NORMALIZE_WHITESPACE
+
+   <Projected CRS: EPSG:3070>
+   Name: NAD83 / Wisconsin Transverse Mercator
+   Axis Info [cartesian]:
+   - X[east]: Easting (metre)
+   - Y[north]: Northing (metre)
+   Area of Use:
+   - name: United States (USA) - Wisconsin.
+   - bounds: (-92.89, 42.48, -86.25, 47.31)
+   Coordinate Operation:
+   - name: Wisconsin Transverse Mercator 83
+   - method: Transverse Mercator
+   Datum: North American Datum 1983
+   - Ellipsoid: GRS 1980
+   - Prime Meridian: Greenwich

--- a/docs/source/howtos/index.rst
+++ b/docs/source/howtos/index.rst
@@ -11,3 +11,4 @@ How-Tos
    :caption: Accessing Metadata
 
    set_dims
+   access_crs

--- a/docs/source/howtos/set_dims.rst
+++ b/docs/source/howtos/set_dims.rst
@@ -3,6 +3,8 @@ Specify your spatial and temporal dimensions
 
 Assuming you have an Xarray object that has some atypical or unusual names
 for its dimensions, we can tell geoxarray what these dimensions represent.
+For more information on what dimensions geoxarray understands see the
+:doc:`../topics/dimensions` documentation.
 
 .. testsetup::
 
@@ -36,6 +38,8 @@ purpose by using
 :attr:`.geo.dims <geoxarray.accessor.GeoDataArrayAccessor.dims>`:
 
 .. testcode::
+
+    import geoxarray
 
     print(data_arr.geo.dims)
 

--- a/docs/source/howtos/set_dims.rst
+++ b/docs/source/howtos/set_dims.rst
@@ -1,5 +1,5 @@
-Specify your spatial and temporal dimensions
-============================================
+Specify spatial and temporal dimensions
+=======================================
 
 Assuming you have an Xarray object that has some atypical or unusual names
 for its dimensions, we can tell geoxarray what these dimensions represent.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,25 +14,6 @@ and plotting.
     Geoxarray is currently in a pre-alpha state and may not do most of what
     you'd expect a library with the above description to do.
 
-.. warning::
-
-    Geoxarray has not had a release yet. Instructions referencing installing
-    from PyPI or conda-forge are there as placeholders and will not run
-    properly until there is a release.
-
-Geoxarray directly uses, borrows from, or is based on the ideas of other open
-source projects including:
-
-* `rioxarray <https://corteva.github.io/rioxarray/stable/>`_
-* `rasterio <https://rasterio.readthedocs.io/en/latest/>`_
-* `satpy <https://satpy.readthedocs.io/en/stable/>`_
-* `pyresample <https://pyresample.readthedocs.io/en/latest/>`_
-* `xgcm <https://xgcm.readthedocs.io/en/latest/>`_
-* `xesmf <https://xesmf.readthedocs.io/en/latest/>`_
-* `The Pangeo Community <https://pangeo.io/>`_
-
-
-
 Geoxarray Documentation
 -----------------------
 
@@ -61,7 +42,8 @@ For more on how this documentation is structured, see
    :glob:
 
    installation
-   topics/*
+   topics/xarray_accessors
+   topics/dimensions
    faq
 
 .. toctree::
@@ -80,4 +62,4 @@ For more on how this documentation is structured, see
    roadmap
    Release Notes <https://github.com/geoxarray/geoxarray/blob/main/CHANGELOG.md>
    GitHub Project <https://github.com/geoxarray/geoxarray>
-
+   related

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,7 @@ For more on how this documentation is structured, see
    installation
    topics/xarray_accessors
    topics/dimensions
+   topics/projections
    faq
 
 .. toctree::

--- a/docs/source/related.rst
+++ b/docs/source/related.rst
@@ -1,0 +1,15 @@
+Related Projects
+================
+
+Geoxarray directly uses, borrows from, or is based on the ideas of other open
+source projects including:
+
+* `rioxarray <https://corteva.github.io/rioxarray/stable/>`_
+* `rasterio <https://rasterio.readthedocs.io/en/latest/>`_
+* `satpy <https://satpy.readthedocs.io/en/stable/>`_
+* `pyresample <https://pyresample.readthedocs.io/en/latest/>`_
+* `xgcm <https://xgcm.readthedocs.io/en/latest/>`_
+* `xesmf <https://xesmf.readthedocs.io/en/latest/>`_
+* `The Pangeo Community <https://pangeo.io/>`_
+
+

--- a/docs/source/topics/dimensions.rst
+++ b/docs/source/topics/dimensions.rst
@@ -9,7 +9,7 @@ dimension and these spatial dimensions:
   reference system (CRS) this will be in the units of the projection space;
   typically meters or degrees. As an example, in a longitude/latitude CRS this
   would likely be the longitude dimension in degrees east.
-* ``y``: The opposite 2D dimension to the ``x`` dimension in a geographic
+* ``y``: The other 2D dimension to the ``x`` dimension in a geographic
   projection space. In a longitude/latitude CRS this would likely be the
   latitude dimension in degrees north.
 * ``vertical``: The elevation, altitude, or vertical dimension. This is
@@ -20,7 +20,8 @@ dimension and these spatial dimensions:
 In well structured or common data schemes, Geoxarray can probably guess what
 these dimensions are by their name or the shape of the array being looked at
 (ex. a 2D array probably has (y, x) dimensions). Geoxarray will internally
-rename these dimensions and this can be verified by doing:
+rename these dimensions and this can be verified by accessing the dimensions
+through the Geoxarray accessor.
 
 .. code-block:: python
 

--- a/docs/source/topics/projections.rst
+++ b/docs/source/topics/projections.rst
@@ -1,0 +1,91 @@
+Projections
+===========
+
+One of the more complex topics when working with geolocated data is geographic
+projections and the conversion or resampling of data between projections.
+You may also see the term projection referred to as a Projected Coordinate
+Reference System (CRS) or just CRS. The below documentation can be seen as
+a primer, but it is still quite limited for this complex topic.
+
+The book "Map Projections" by Battersby [#]_ describes map projections:
+
+.. code-block:: text
+
+    Map projection is the process of transforming angular
+    (spherical / elliptical) coordinates into planar coordinates. All map
+    projections introduce distortion (e.g., to areas, angles, distances) in the
+    resulting planar coordinates. Understanding what, where, and how much
+    distortion is introduced is an important consideration for spatial
+    computations and visual interpretation of spatial patterns, as well as for
+    general aesthetics of any map.
+
+Spatial projections describe how to create a flat 2D version of our round 3D
+Earth that may be easier to work with or describe than the original
+representation used by our data.
+
+.. image:: http://gistbok.ucgis.org/sites/default/files/figure2-projections.png
+   :width: 450px
+   :target: http://gistbok.ucgis.org/bok-topics/map-projections
+
+These projections or coordinate reference systems will consist of things like
+a model of the Earth (datum/ellipsoid), a reference or center longitude, a
+reference or center latitude, and the type of shape or algorithm used to
+transform points to and from the projection. For example, a geostationary
+projection might "see" the Earth like:
+
+.. image:: https://proj.org/_images/geos.png
+   :width: 300px
+   :target: https://proj.org/operations/projections/geos.html
+
+Or a lambert conformal conic (LCC) projection might "see" it like:
+
+.. image:: https://proj.org/_images/lcc.png
+   :width: 300px
+   :target: https://proj.org/operations/projections/lcc.html
+
+Changing the parameters for a particular CRS will change what region of the
+Earth is covered and what level of distortion is seen compared to the real
+Earth.
+
+Properly defining the projection of your data is important in order to properly
+compare data from multiple sources. Two pixels at longitude 0 and latitude 0
+aren't actually representing the same location if those coordinates are defined
+for different CRSes. Typically to make comparison the easiest it can be
+coordinates are transformed or data resampled to one single CRS.
+For example, data from a forecast model may be defined
+on a longitude/latitude projection with coordinates specified in degrees. Data
+from a geostationary satellite might be on a geostationary projection with
+coordinates in meters. If you wanted to combine these data you'd need to
+transform the coordinates from one projection to the other.
+
+.. [#]
+
+   Battersby, S. (2017). Map Projections. The Geographic Information Science &
+   Technology Body of Knowledge (2nd Quarter 2017 Edition), John P. Wilson (ed.). DOI: 10.22224/gistbok/2017.2.7
+
+Projection definitions
+----------------------
+
+There are many different types of projections.
+Geoxarray uses the :doc:`pyproj <pyproj:index>` library's ``CRS`` object to define
+all of its Coordinate Reference Systems and the transformation of coordinates
+between them. Pyproj depends on the lower-level :doc:`PROJ <proj:index>` C++
+library which defines the actual coordinate transformation algorithms and
+maintains definitions for predefined CRSes (ex. EPSG codes). You can find a
+list of the supported PROJ definitions :doc:`here <proj:operations/projections/index>`.
+
+Anywhere in Geoxarray that a CRS is needed a :class:`~pyproj.crs.CRS` object
+from ``pyproj`` will be used. However, these objects aren't always compatible
+with other libraries that geoxarray uses or they may not serialize well to
+on-disk formats (ex. NetCDF CF). In these cases geoxarray also uses a
+`CF-standard "grid_mapping" <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/apf.html>`_
+definition to persist CRS information to an xarray object and that may include
+a `Well-known Text (WKT) <https://proj.org/en/latest/development/reference/cpp/cpp_general.html#general_doc_1WKT2>`
+version of the CRS in a ``crs_wkt`` attribute. See the pyproj
+:doc:`Getting Started <pyproj:examples>` documentation for some examples of
+different CRS options.
+
+Lastly, a projection is not the only thing that is needed to describe where
+your data is on the Earth. Typically there are also x, or y, or other coordinate
+variables defining the positions of each "pixel" of your data. At the time of
+writing Geoxarray does not do anything with these coordinates.

--- a/docs/source/topics/xarray_accessors.rst
+++ b/docs/source/topics/xarray_accessors.rst
@@ -1,0 +1,13 @@
+Xarray Accessors
+================
+
+Geoxarray's primary interface is through an xarray accessor with the name
+``.geo``. The
+`xarray accessor design <https://docs.xarray.dev/en/stable/internals/extending-xarray.html>`_
+is the suggested way to extend xarray functionality. This accessor gives you
+access to geoxarray's functionality on any xarray object
+(``DataArray`` or ``Dataset``) by calling methods or properties of it. For
+example, ``my_data_array.geo.crs`` to get the Coordinate Reference System
+information for ``my_data_array``. Due to this, geoxarray differs from a more
+traditional software library where you would call functions or create objects
+directly from the library.

--- a/geoxarray/accessor.py
+++ b/geoxarray/accessor.py
@@ -151,9 +151,10 @@ class _SharedGeoAccessor:
     def write_dims(self) -> XarrayObject:
         """Rename object's dimensions to match geoxarray's preferred dimension names.
 
-        This uses Xarray's :meth:`xarray.DataArray.rename` or :meth:`xarray.Dataset.rename`
-        methods which always produce copies of the original object. It is not possible to
-        do this operation "inplace".
+        This is a simple wrapper around Xarray's :meth:`xarray.DataArray.rename`
+        or :meth:`xarray.Dataset.rename` methods along with ``.geo.dim_map`` to
+        rename the dimension names. These methods always produce copies of the
+        original object. It is not possible to do this operation "inplace".
 
         """
         obj_copy = self._get_obj(inplace=False)
@@ -364,7 +365,7 @@ class GeoDatasetAccessor(_SharedGeoAccessor):
         # tell the dim_map property to produce the "as-is" dim map
         obj_copy.geo._dim_map = None
         dim_map = obj_copy.geo.dim_map
-        for data_arr in self._obj.data_vars.values():
+        for data_arr in obj_copy.data_vars.values():
             dims = {k: v for k, v in all_dims.items() if v in data_arr.dims}
             if not dims:
                 continue
@@ -429,7 +430,8 @@ class GeoDataArrayAccessor(_SharedGeoAccessor):
         by best guess.
 
         This information does not rename or modify the data of the Xarray
-        object itself.
+        object itself. To easily rename the dimensions in a Geoxarray-friendly
+        manner, follow a call of this method with :meth:`write_dims`.
 
         Parameters
         ----------

--- a/geoxarray/accessor.py
+++ b/geoxarray/accessor.py
@@ -148,9 +148,15 @@ class _SharedGeoAccessor:
             sizes_dict[self.dim_map.get(dname, dname)] = size
         return self._obj.sizes.__class__(sizes_dict)
 
-    def write_dims(self, inplace: bool = False):
-        """Rename object's dimensions to match geoxarray's preferred dimension names."""
-        obj_copy = self._get_obj(inplace)
+    def write_dims(self) -> XarrayObject:
+        """Rename object's dimensions to match geoxarray's preferred dimension names.
+
+        This uses Xarray's :meth:`xarray.DataArray.rename` or :meth:`xarray.Dataset.rename`
+        methods which always produce copies of the original object. It is not possible to
+        do this operation "inplace".
+
+        """
+        obj_copy = self._get_obj(inplace=False)
         return obj_copy.rename(self.dim_map)
 
     @property

--- a/geoxarray/tests/test_accessor/test_accessor_data_arr.py
+++ b/geoxarray/tests/test_accessor/test_accessor_data_arr.py
@@ -115,3 +115,22 @@ def test_no_crs_write_crs(inplace, gmap_var_name):
 def test_pyresample_area_2d_crs():
     data_arr = pyr_geos_area_2d()
     assert data_arr.geo.crs == data_arr.attrs["area"].crs
+
+
+def test_pyresample_write_crs():
+    data_arr = pyr_geos_area_2d()
+    assert "grid_mapping" not in data_arr.encoding
+    assert "grid_mapping" not in data_arr.attrs
+    assert "spatial_ref" not in data_arr.coords
+    new_data_arr = data_arr.geo.write_crs()
+    assert "grid_mapping" in new_data_arr.encoding
+    assert "grid_mapping" not in new_data_arr.attrs
+    assert "spatial_ref" in new_data_arr.coords
+
+
+def test_write_crs_no_crs_found():
+    data_arr = no_crs_no_dims_2d()
+    assert "grid_mapping" not in data_arr
+    assert data_arr.geo.crs is None
+    with pytest.raises(RuntimeError):
+        data_arr.geo.write_crs()

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(path.join(here, "requirements.txt")) as requirements_file:
 
 extras_require = {
     "pyresample": ["pyresample"],
-    "docs": ["sphinx_rtd_theme", "numpydoc", "sphinx_copybutton", "sphinxcontrib-apidoc"],
+    "docs": ["sphinx_rtd_theme", "numpydoc", "sphinx_copybutton", "sphinxcontrib-apidoc", "pyresample", "dask"],
 }
 all_extras = []
 for extra_deps in extras_require.values():

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ with open(path.join(here, "requirements.txt")) as requirements_file:
 
 extras_require = {
     "pyresample": ["pyresample"],
+    "docs": ["sphinx_rtd_theme", "numpydoc", "sphinx_copybutton", "sphinxcontrib-apidoc"],
 }
 all_extras = []
 for extra_deps in extras_require.values():


### PR DESCRIPTION
Continuation of #31 where I noticed that there's a missing use case of a non-CF xarray object and you want to write the CRS that was found.