### PR TITLE
Add spatial coordinate writing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          mamba install -y --force-reinstall -c arrow-nightlies pyarrow;
+          mamba install -y --force-reinstall arrow-nightlies::pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
+          conda uninstall --force-remove -y pyarrow;
           mamba install -y --override-channels -c arrow-nightlies pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,8 +110,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          conda uninstall --force-remove -y pyarrow libarrow aws-crt-cpp;
-          mamba install -y --override-channels -c arrow-nightlies pyarrow;
+          python -m pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --prefer-binary --pre pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,9 @@ jobs:
       - name: Install unstable dependencies
         if: matrix.experimental == true
         shell: bash -l {0}
+        # NOTE: pyarrow only needed for pandas 3 unstable dependency
         run: |
+          python -m pip install pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
+          conda uninstall --force-remove -y pyarrow;
           python -m pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --prefer-binary --pre pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,9 +109,8 @@ jobs:
       - name: Install unstable dependencies
         if: matrix.experimental == true
         shell: bash -l {0}
-        # NOTE: pyarrow only needed for pandas 3 unstable dependency
         run: |
-          python -m pip install pyarrow;
+          mamba install -y -c arrow-nightlies pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          mamba install -y --force-reinstall --override-channels -c arrow-nightlies pyarrow;
+          mamba install -y --override-channels -c arrow-nightlies pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          mamba install -y -c arrow-nightlies pyarrow;
+          mamba install -y --force-reinstall -c arrow-nightlies pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          conda uninstall --force-remove -y pyarrow;
+          conda uninstall --force-remove -y pyarrow libarrow aws-crt-cpp;
           mamba install -y --override-channels -c arrow-nightlies pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          mamba install -y --force-reinstall arrow-nightlies::pyarrow;
+          mamba install -y --force-reinstall --override-channels -c arrow-nightlies pyarrow;
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,7 @@ extensions = [
     "numpydoc",
     "sphinx_copybutton",
     "sphinxcontrib.apidoc",
+    "sphinx_autodoc_typehints",
 ]
 
 # Mock

--- a/docs/source/howtos/coordinates.rst
+++ b/docs/source/howtos/coordinates.rst
@@ -1,0 +1,46 @@
+Add spatial coordinates
+=======================
+
+Geoxarray can extract the information from a ``DataArray`` to generate
+:doc:`spatial coordinates <../topics/coordinates>`. These spatial
+coordinates will be stored in ``.coords`` of the ``DataArray`` and can
+be used for labeled indexing. Spatial coordinates are only ever added
+for :doc:`dimensions <../topics/dimensions>` that geoxarray understands.
+See :doc:`set_dims` for ways to work with non-standard dimension names.
+
+To get a copy of your ``DataArray`` with spatial coordinates assigned
+call the ``.geo.write_spatial_coords()`` method:
+
+.. testcode::
+
+   import xarray as xr
+   import numpy as np
+   import geoxarray
+
+   my_data_arr = xr.DataArray(
+       np.zeros((20, 10)),
+       dims=("y", "x"),
+       attrs={
+           "ModelPixelScale": [1002.008644, 1002.008644, 0.0],
+           "ModelTiepoint": [0.0, 0.0, 0.0, -5434894.885056, 5434894.885056, 0.0],
+       },
+   )
+   new_data_arr = my_data_arr.geo.write_spatial_coords()
+   print(new_data_arr)
+
+Which will make the DataArray look like:
+
+.. testoutput::
+
+   <xarray.DataArray (y: 20, x: 10)>
+   ...
+   Coordinates:
+     * y        (y) float64 5.434e+06 5.433e+06 5.432e+06 ... 5.416e+06 5.415e+06
+     * x        (x) float64 -5.434e+06 -5.433e+06 ... -5.426e+06 -5.425e+06
+   Attributes:
+       ModelPixelScale:  [1002.008644, 1002.008644, 0.0]
+       ModelTiepoint:    [0.0, 0.0, 0.0, -5434894.885056, 5434894.885056, 0.0]
+
+See the :meth:`~geoxarray.accessor.GeoDataArrayAccessor.write_spatial_coords`
+API documentation for more information on supported and expected metadata
+structure for this operation.

--- a/docs/source/howtos/index.rst
+++ b/docs/source/howtos/index.rst
@@ -13,3 +13,4 @@ How-Tos
    set_dims
    access_crs
    write_crs
+   coordinates

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,6 +45,7 @@ For more on how this documentation is structured, see
    topics/xarray_accessors
    topics/dimensions
    topics/projections
+   topics/coordinates
    faq
 
 .. toctree::

--- a/docs/source/topics/coordinates.rst
+++ b/docs/source/topics/coordinates.rst
@@ -1,0 +1,37 @@
+Coordinates
+===========
+
+One of the core functionalities made available through Xarray is the ability
+to add :term:`coordinate arrays <xarray:Coordinate>` to a DataArray or
+Dataset. By defining coordinate arrays our DataArrays we essentially label
+the dimensions like ticks on a plot axis. For more information on coordinate
+functionality see the :term:`Xarray documentation <xarray:Coordinate>`.
+
+The below sections go into the details of how Geoxarray uses and defines
+certain types of coordinate arrays.
+
+Spatial Coordinates
+-------------------
+
+Geoxarray is able to create and use spatial coordinates for the
+spatial :doc:`dimensions` of a ``DataArray``. This typically falls
+into one of two different cases:
+
+* 1-dimensional ``x`` and ``y`` coordinate arrays
+* 2-dimensional coordinate arrays with the ``y`` dimension on the row/vertical
+  axis and ``x`` on the column/horizontal dimension.
+
+The 1-dimensional coordinates are reserved for uniformly-spaced "grids" of
+data. Due to these arrays being uniformly spaced and 1-dimensional, it is
+usually easy and efficient to index or slice along using these labels.
+
+The 2-dimensional coordinate arrays case is typically for
+non-uniformly-spaced data that requires a 2D longitude and 2D latitude array
+to accurately define the location of every element of the data. This may also
+arise if geolocation information was computed from a series of Ground Control
+Points (GCPs).
+
+At the time of writing it is not currently efficient to index based on
+2-dimensional coordinate arrays. Due to their size it may also be helpful
+to define 2D coordinate arrays as a dask array or other Xarray-compatible lazy
+array.

--- a/docs/source/topics/coordinates.rst
+++ b/docs/source/topics/coordinates.rst
@@ -7,7 +7,7 @@ Dataset. By defining coordinate arrays our DataArrays we essentially label
 the dimensions like ticks on a plot axis. For more information on coordinate
 functionality see the :term:`Xarray documentation <xarray:Coordinate>`.
 
-The below sections go into the details of how Geoxarray uses and defines
+The below sections go into the details of how geoxarray uses and defines
 certain types of coordinate arrays.
 
 Spatial Coordinates

--- a/geoxarray/accessor.py
+++ b/geoxarray/accessor.py
@@ -52,7 +52,7 @@ import xarray as xr
 from pyproj import CRS
 from pyproj.exceptions import CRSError
 
-from .coords import generate_spatial_coords
+from .coords import spatial_coords
 
 try:
     from pyresample.geometry import AreaDefinition, SwathDefinition
@@ -322,7 +322,7 @@ class _SharedGeoAccessor(Generic[XarrayObject]):
                 continue
             yield var_grid_mapping
 
-    def write_spatial_coords(self, inplace: bool = False) -> xarray.DataArray:
+    def write_spatial_coords(self) -> xarray.DataArray:
         """Write 'y' and 'x' coordinate arrays to ``.coords``.
 
         This operation always produces a new copy of the xarray object. See
@@ -333,12 +333,13 @@ class _SharedGeoAccessor(Generic[XarrayObject]):
         representing the center of the pixel.
 
         """
-        obj = self._get_obj(inplace)
+        # don't make an extra copy, assign_coords will do it for us
+        obj = self._get_obj(inplace=True)
         geo_dim_map = obj.geo._geo_dim_map
         y_dim_name = geo_dim_map["y"]
         x_dim_name = geo_dim_map["x"]
 
-        coords_dict = generate_spatial_coords(obj)
+        coords_dict = spatial_coords(obj)
         obj = obj.assign_coords(
             {
                 y_dim_name: coords_dict["y"],

--- a/geoxarray/accessor.py
+++ b/geoxarray/accessor.py
@@ -132,6 +132,12 @@ class _SharedGeoAccessor(Generic[XarrayObject]):
 
         return self._dim_map
 
+    @property
+    def _geo_dim_map(self):
+        """Map geoxarray preferred dim name to current data dimension name."""
+        dim_map = self.dim_map
+        return {gx_dim: curr_dim for curr_dim, gx_dim in dim_map.items()}
+
     def set_dims(self, *args, **kwargs) -> None:
         """Tell geoxarray the names of the provided dimensions in this Xarray object."""
         raise NotImplementedError()
@@ -328,6 +334,9 @@ class _SharedGeoAccessor(Generic[XarrayObject]):
         """
         # TODO: Add dask functionality?
         obj = self._get_obj(inplace)
+        geo_dim_map = obj.geo._geo_dim_map
+        y_dim_name = geo_dim_map["y"]
+        x_dim_name = geo_dim_map["x"]
         if "ModelPixelScale" in obj.attrs:
             # tifffile as loaded by kerchunk
             width = obj.geo.sizes["x"]
@@ -343,8 +352,8 @@ class _SharedGeoAccessor(Generic[XarrayObject]):
         obj = obj.assign_coords(
             {
                 # FIXME: This is the wrong dim map (need the reverse)
-                obj.geo.dim_map["y"]: y_coord,
-                obj.geo.dim_map["x"]: x_coord,
+                y_dim_name: y_coord,
+                x_dim_name: x_coord,
             }
         )
         return obj

--- a/geoxarray/accessor.py
+++ b/geoxarray/accessor.py
@@ -329,6 +329,9 @@ class _SharedGeoAccessor(Generic[XarrayObject]):
         :meth:`xarray.DataArray.assign_coords` and
         :meth:`xarray.Dataset.assign_coords`.
 
+        See :func:`geoxarray.coords.spatial_coords` for supported metadata
+        structures.
+
         Coordinate arrays are currently always a single point per data pixel
         representing the center of the pixel.
 

--- a/geoxarray/coords.py
+++ b/geoxarray/coords.py
@@ -1,0 +1,42 @@
+# Copyright geoxarray Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper functions for generating coordinate arrays for Xarray objects.
+
+The functions in this module are public, but typically don't need to be
+directly imported by users. It is recommended to use the various coordinate
+methods of the geoxarray Xarray accessor (``.geo``).
+
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import xarray as xr
+
+
+def generate_spatial_coords(data_arr: xr.DataArray) -> dict[str, npt.ArrayLike]:
+    # TODO: Add dask functionality?
+    if "ModelPixelScale" in data_arr.attrs:
+        # tifffile as loaded by kerchunk
+        width = data_arr.geo.sizes["x"]
+        height = data_arr.geo.sizes["y"]
+        x_pixel_res, y_pixel_res = data_arr.attrs["ModelPixelScale"][:2]
+        x_left, y_top = data_arr.attrs["ModelTiepoint"][3:5]
+        x_coord = (x_left + x_pixel_res / 2.0) + np.arange(width) * x_pixel_res
+        y_coord = (y_top - y_pixel_res / 2.0) - np.arange(height) * y_pixel_res
+        # XXX: What to do with  'GTRasterTypeGeoKey': <RasterPixel.IsArea: 1>?
+    else:
+        raise RuntimeError("Unknown data structure. Can't compute spatial coordinates.")
+    return {"y": y_coord, "x": x_coord}

--- a/geoxarray/coords.py
+++ b/geoxarray/coords.py
@@ -26,8 +26,30 @@ import numpy.typing as npt
 import xarray as xr
 
 
-def generate_spatial_coords(data_arr: xr.DataArray) -> dict[str, npt.ArrayLike]:
+def spatial_coords(data_arr: xr.DataArray) -> dict[str, npt.ArrayLike]:
+    """Generate 1-dimensional spatial coordinate arrays for a DataArray.
+
+    Parameters
+    ----------
+    data_arr
+        DataArray object to extract geolocation information from and
+        generate the corresponding coordinate arrays.
+
+    Returns
+    -------
+        Dictionary mapping "x" and "y" dimension names to the corresponding
+        1-dimensional array-like object. Currently only numpy arrays are
+        returned.
+
+    Raises
+    ------
+    ValueError
+        If the necessary metadata can't be found in the DataArray
+
+    """
     # TODO: Add dask functionality?
+    # TODO: Add pyresample AreaDefinition support
+    # TODO: Add 2D y/x nonuniform coordinates (pyresample's SwathDefinition, GCPs, etc)
     if "ModelPixelScale" in data_arr.attrs:
         # tifffile as loaded by kerchunk
         width = data_arr.geo.sizes["x"]
@@ -38,5 +60,5 @@ def generate_spatial_coords(data_arr: xr.DataArray) -> dict[str, npt.ArrayLike]:
         y_coord = (y_top - y_pixel_res / 2.0) - np.arange(height) * y_pixel_res
         # XXX: What to do with  'GTRasterTypeGeoKey': <RasterPixel.IsArea: 1>?
     else:
-        raise RuntimeError("Unknown data structure. Can't compute spatial coordinates.")
+        raise ValueError("Unknown data structure. Can't compute spatial coordinates.")
     return {"y": y_coord, "x": x_coord}

--- a/geoxarray/coords.py
+++ b/geoxarray/coords.py
@@ -29,6 +29,10 @@ import xarray as xr
 def spatial_coords(data_arr: xr.DataArray) -> dict[str, npt.ArrayLike]:
     """Generate 1-dimensional spatial coordinate arrays for a DataArray.
 
+    Currently supported cases are:
+
+    * geotiff read with kerchunk via tifffile
+
     Parameters
     ----------
     data_arr

--- a/geoxarray/tests/test_accessor/_data_array_cases.py
+++ b/geoxarray/tests/test_accessor/_data_array_cases.py
@@ -15,6 +15,7 @@
 """Test cases for DataArray-specific interfaces."""
 from __future__ import annotations
 
+import pytest
 import xarray as xr
 from dask import array as da
 from pyproj import CRS
@@ -154,6 +155,7 @@ def no_crs_no_dims_2d():
     return xr.DataArray(da.empty((Y_DIM_SIZE, X_DIM_SIZE)))
 
 
+@pytest.mark.skipif(AreaDefinition is None, reason="Test dependency missing: pyresample")
 def pyr_geos_area_2d() -> xr.DataArray:
     geos_crs = CRS.from_dict(
         {
@@ -170,4 +172,12 @@ def pyr_geos_area_2d() -> xr.DataArray:
     )
     data_arr = no_crs_no_dims_2d()
     data_arr.attrs["area"] = area
+    return data_arr
+
+
+def tifffile_with_geometa() -> xr.DataArray:
+    """Create DataArray mimicking kerchunk's use of tifffile."""
+    data_arr = geotiff_y_x()
+    data_arr.attrs["ModelPixelScale"] = [1002.008644, 1002.008644, 0.0]
+    data_arr.attrs["ModelTiepoint"] = [0.0, 0.0, 0.0, -5434894.885056, 5434894.885056, 0.0]
     return data_arr

--- a/geoxarray/tests/test_accessor/_data_array_cases.py
+++ b/geoxarray/tests/test_accessor/_data_array_cases.py
@@ -181,3 +181,11 @@ def tifffile_with_geometa() -> xr.DataArray:
     data_arr.attrs["ModelPixelScale"] = [1002.008644, 1002.008644, 0.0]
     data_arr.attrs["ModelTiepoint"] = [0.0, 0.0, 0.0, -5434894.885056, 5434894.885056, 0.0]
     return data_arr
+
+
+def tifffile_nonyx_with_geometa() -> xr.DataArray:
+    """Create DataArray mimicking kerchunk's use of tifffile."""
+    data_arr = geotiff_b_a()
+    data_arr.attrs["ModelPixelScale"] = [1002.008644, 1002.008644, 0.0]
+    data_arr.attrs["ModelTiepoint"] = [0.0, 0.0, 0.0, -5434894.885056, 5434894.885056, 0.0]
+    return data_arr

--- a/geoxarray/tests/test_accessor/_shared.py
+++ b/geoxarray/tests/test_accessor/_shared.py
@@ -15,6 +15,8 @@
 """Shared information and utilities for the data cases."""
 from __future__ import annotations
 
+import os
+
 import xarray as xr
 from pyproj import CRS
 
@@ -25,6 +27,8 @@ try:
 except ImportError:
     AreaDefinition = None
 
+IS_CI = os.getenv("CI", "false").lower() == "true"
+MISSING_PYRESAMPLE = AreaDefinition is None and not IS_CI
 
 X_DIM_SIZE = 20
 Y_DIM_SIZE = 10

--- a/geoxarray/tests/test_accessor/test_accessor_data_arr.py
+++ b/geoxarray/tests/test_accessor/test_accessor_data_arr.py
@@ -39,9 +39,9 @@ from ._data_array_cases import (
 )
 from ._shared import (
     ALT_DIM_SIZE,
+    MISSING_PYRESAMPLE,
     X_DIM_SIZE,
     Y_DIM_SIZE,
-    AreaDefinition,
     check_written_crs,
 )
 
@@ -113,13 +113,13 @@ def test_no_crs_write_crs(inplace, gmap_var_name):
     check_written_crs(new_data_arr, new_crs, gmap_var_name)
 
 
-@pytest.mark.skipif(AreaDefinition is None, reason="Missing 'pyresample' dependency")
+@pytest.mark.skipif(MISSING_PYRESAMPLE, reason="Missing 'pyresample' dependency")
 def test_pyresample_area_2d_crs():
     data_arr = pyr_geos_area_2d()
     assert data_arr.geo.crs == data_arr.attrs["area"].crs
 
 
-@pytest.mark.skipif(AreaDefinition is None, reason="Test dependency missing: pyresample")
+@pytest.mark.skipif(MISSING_PYRESAMPLE, reason="Test dependency missing: pyresample")
 def test_pyresample_write_crs():
     data_arr = pyr_geos_area_2d()
     assert "grid_mapping" not in data_arr.encoding

--- a/geoxarray/tests/test_accessor/test_accessor_data_arr.py
+++ b/geoxarray/tests/test_accessor/test_accessor_data_arr.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the xarray DataArray-specific accessor."""
-
+import numpy as np
 import pytest
 from pyproj import CRS
 
@@ -34,6 +34,7 @@ from ._data_array_cases import (
     no_crs_no_dims_2d,
     pyr_geos_area_2d,
     raw_coords_lats1d_lons1d,
+    tifffile_with_geometa,
 )
 from ._shared import (
     ALT_DIM_SIZE,
@@ -117,6 +118,7 @@ def test_pyresample_area_2d_crs():
     assert data_arr.geo.crs == data_arr.attrs["area"].crs
 
 
+@pytest.mark.skipif(AreaDefinition is None, reason="Test dependency missing: pyresample")
 def test_pyresample_write_crs():
     data_arr = pyr_geos_area_2d()
     assert "grid_mapping" not in data_arr.encoding
@@ -135,3 +137,59 @@ def test_write_crs_no_crs_found():
     assert data_arr.geo.crs is None
     with pytest.raises(RuntimeError):
         data_arr.geo.write_crs()
+
+
+def test_create_coords_tifffile():
+    data_arr = tifffile_with_geometa()
+    assert "y" not in data_arr.coords
+    assert "x" not in data_arr.coords
+
+    new_data_arr = data_arr.geo.write_spatial_coords()
+    assert "y" in new_data_arr.coords
+    assert "x" in new_data_arr.coords
+    assert "y" not in data_arr.coords
+    assert "x" not in data_arr.coords
+    np.testing.assert_allclose(
+        new_data_arr.coords["x"],
+        np.array(
+            [
+                -5434393.880734,
+                -5433391.87209,
+                -5432389.863446,
+                -5431387.854802,
+                -5430385.846158,
+                -5429383.837514,
+                -5428381.82887,
+                -5427379.820226,
+                -5426377.811582,
+                -5425375.802938,
+                -5424373.794294,
+                -5423371.78565,
+                -5422369.777006,
+                -5421367.768362,
+                -5420365.759718,
+                -5419363.751074,
+                -5418361.74243,
+                -5417359.733786,
+                -5416357.725142,
+                -5415355.716498,
+            ]
+        ),
+    )
+    np.testing.assert_allclose(
+        new_data_arr.coords["y"],
+        np.array(
+            [
+                5434393.880734,
+                5433391.87209,
+                5432389.863446,
+                5431387.854802,
+                5430385.846158,
+                5429383.837514,
+                5428381.82887,
+                5427379.820226,
+                5426377.811582,
+                5425375.802938,
+            ]
+        ),
+    )

--- a/geoxarray/tests/test_accessor/test_accessor_data_arr.py
+++ b/geoxarray/tests/test_accessor/test_accessor_data_arr.py
@@ -139,7 +139,13 @@ def test_write_crs_no_crs_found():
         data_arr.geo.write_crs()
 
 
-def test_create_coords_tifffile():
+def test_write_coords_unknown():
+    data_arr = no_crs_no_dims_2d()
+    with pytest.raises(RuntimeError):
+        data_arr.geo.write_spatial_coords()
+
+
+def test_write_coords_tifffile():
     data_arr = tifffile_with_geometa()
     assert "y" not in data_arr.coords
     assert "x" not in data_arr.coords

--- a/geoxarray/tests/test_accessor/test_accessor_data_arr.py
+++ b/geoxarray/tests/test_accessor/test_accessor_data_arr.py
@@ -34,6 +34,7 @@ from ._data_array_cases import (
     no_crs_no_dims_2d,
     pyr_geos_area_2d,
     raw_coords_lats1d_lons1d,
+    tifffile_nonyx_with_geometa,
     tifffile_with_geometa,
 )
 from ._shared import (
@@ -145,18 +146,27 @@ def test_write_coords_unknown():
         data_arr.geo.write_spatial_coords()
 
 
-def test_write_coords_tifffile():
-    data_arr = tifffile_with_geometa()
+@pytest.mark.parametrize(
+    ("data_func", "y_dim", "x_dim"),
+    [
+        (tifffile_with_geometa, "y", "x"),
+        (tifffile_nonyx_with_geometa, "a", "b"),
+    ],
+)
+def test_write_coords_tifffile(data_func, y_dim, x_dim):
+    data_arr = data_func()
     assert "y" not in data_arr.coords
     assert "x" not in data_arr.coords
 
     new_data_arr = data_arr.geo.write_spatial_coords()
-    assert "y" in new_data_arr.coords
-    assert "x" in new_data_arr.coords
+    assert y_dim in new_data_arr.coords
+    assert x_dim in new_data_arr.coords
     assert "y" not in data_arr.coords
     assert "x" not in data_arr.coords
+    assert y_dim not in data_arr.coords
+    assert x_dim not in data_arr.coords
     np.testing.assert_allclose(
-        new_data_arr.coords["x"],
+        new_data_arr.coords[x_dim],
         np.array(
             [
                 -5434393.880734,
@@ -183,7 +193,7 @@ def test_write_coords_tifffile():
         ),
     )
     np.testing.assert_allclose(
-        new_data_arr.coords["y"],
+        new_data_arr.coords[y_dim],
         np.array(
             [
                 5434393.880734,

--- a/geoxarray/tests/test_accessor/test_accessor_data_arr.py
+++ b/geoxarray/tests/test_accessor/test_accessor_data_arr.py
@@ -142,7 +142,7 @@ def test_write_crs_no_crs_found():
 
 def test_write_coords_unknown():
     data_arr = no_crs_no_dims_2d()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         data_arr.geo.write_spatial_coords()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,4 +46,10 @@ warn_unreachable = true
 warn_unused_configs = true
 
 [tool.pytest.ini_options]
-filterwarnings = ["error", "ignore:numpy.ndarray size changed:RuntimeWarning"]
+filterwarnings = [
+    "error",
+    "ignore:numpy.ndarray size changed:RuntimeWarning",
+    # dateutil needs a new release
+    # https://github.com/dateutil/dateutil/issues/1314
+    'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning:dateutil',
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ numpydoc
 sphinx-copybutton
 sphinx_rtd_theme
 sphinxcontrib-apidoc
+sphinx-autodoc-typehints
 # Package optional dependencies that are required for testing
 pyresample
 dask


### PR DESCRIPTION
As discussed in the xrefcoord issue (https://github.com/carbonplan/xrefcoord/issues/12), I'd like the xrefcoord project to have the option of using geoxarray to generate their coordinate arrays for their kerchunk-based geotiff datasets which are loaded with tifffile. This PR is meant to make that possible with a new `.geo.write_spatial_coords` method. At the time of writing it is very simple, buggy, and only supports this specific use case (kerchunk loading with tifffile).

Feedback is very very welcome.

FYI @maxrjones

TODO:

- [ ] Documentation
- [ ] More tests (error cases, non-yx dimension cases, etc)

